### PR TITLE
Add docker 17.05.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM docker/compose:1.12.0
 
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    apk update && \
+    apk upgrade && \
+    apk add --no-cache bash git openssh curl 'docker=17.05.0-r0'


### PR DESCRIPTION
We want to be able to do `docker system prune` to free up space in CI.

I pushed this to dockerhub under `hfaulds/compose-git` because we haven't versioned our dockerhub image and have used it on this branch and seen CI pass: https://circleci.com/gh/overleaf/write_latex/8634.